### PR TITLE
Added sync.Map to benchmarks

### DIFF
--- a/fastcache_timing_test.go
+++ b/fastcache_timing_test.go
@@ -299,3 +299,85 @@ func BenchmarkStdMapSetGet(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkSyncMapSet(b *testing.B) {
+	const items = 1 << 16
+	m := sync.Map{}
+	b.ReportAllocs()
+	b.SetBytes(items)
+	b.RunParallel(func(pb *testing.PB) {
+		k := []byte("\x00\x00\x00\x00")
+		v := "xyza"
+		for pb.Next() {
+			for i := 0; i < items; i++ {
+				k[0]++
+				if k[0] == 0 {
+					k[1]++
+				}
+				m.Store(string(k), v)
+			}
+		}
+	})
+}
+
+func BenchmarkSyncMapGet(b *testing.B) {
+	const items = 1 << 16
+	m := sync.Map{}
+	k := []byte("\x00\x00\x00\x00")
+	v := "xyza"
+	for i := 0; i < items; i++ {
+		k[0]++
+		if k[0] == 0 {
+			k[1]++
+		}
+		m.Store(string(k), v)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(items)
+	b.RunParallel(func(pb *testing.PB) {
+		k := []byte("\x00\x00\x00\x00")
+		for pb.Next() {
+			for i := 0; i < items; i++ {
+				k[0]++
+				if k[0] == 0 {
+					k[1]++
+				}
+				vv, ok := m.Load(string(k))
+				if !ok || vv.(string) != string(v) {
+					panic(fmt.Errorf("BUG: unexpected value; got %q; want %q", vv, v))
+				}
+			}
+		}
+	})
+}
+
+func BenchmarkSyncMapSetGet(b *testing.B) {
+	const items = 1 << 16
+	m := sync.Map{}
+	b.ReportAllocs()
+	b.SetBytes(2 * items)
+	b.RunParallel(func(pb *testing.PB) {
+		k := []byte("\x00\x00\x00\x00")
+		v := "xyza"
+		for pb.Next() {
+			for i := 0; i < items; i++ {
+				k[0]++
+				if k[0] == 0 {
+					k[1]++
+				}
+				m.Store(string(k), v)
+			}
+			for i := 0; i < items; i++ {
+				k[0]++
+				if k[0] == 0 {
+					k[1]++
+				}
+				vv, ok := m.Load(string(k))
+				if !ok || vv.(string) != string(v) {
+					panic(fmt.Errorf("BUG: unexpected value; got %q; want %q", vv, v))
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
This is an interesting comparison. I'll leave updating the readme to you.
```
GOMAXPROCS=4 go test github.com/VictoriaMetrics/fastcache -bench=. -benchtime=10s
goos: darwin
goarch: amd64
pkg: github.com/VictoriaMetrics/fastcache
BenchmarkBigCacheSet-4              2000      10263033 ns/op       6.39 MB/s     4660370 B/op           6 allocs/op
BenchmarkBigCacheGet-4              3000       6929140 ns/op       9.46 MB/s      630875 B/op      131074 allocs/op
BenchmarkBigCacheSetGet-4           1000      16040092 ns/op       8.17 MB/s     5046744 B/op      131083 allocs/op
BenchmarkCacheSet-4                 5000       3299233 ns/op      19.86 MB/s        4474 B/op           1 allocs/op
BenchmarkCacheGet-4                10000       2094759 ns/op      31.29 MB/s        2237 B/op           0 allocs/op
BenchmarkCacheSetGet-4              2000       6498307 ns/op      20.17 MB/s       11187 B/op           4 allocs/op
BenchmarkStdMapSet-4                2000      11397262 ns/op       5.75 MB/s      268414 B/op       65537 allocs/op
BenchmarkStdMapGet-4                5000       2900110 ns/op      22.60 MB/s        2563 B/op          13 allocs/op
BenchmarkStdMapSetGet-4              200      68080149 ns/op       1.93 MB/s      324790 B/op       65547 allocs/op
BenchmarkSyncMapSet-4               1000      23698289 ns/op       2.77 MB/s     3417219 B/op      262277 allocs/op
BenchmarkSyncMapGet-4              10000       1337885 ns/op      48.98 MB/s        1273 B/op          39 allocs/op
BenchmarkSyncMapSetGet-4            2000       8980098 ns/op      14.60 MB/s     3412536 B/op      262210 allocs/op
```