### PR TITLE
Fix generation overflow

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -19,6 +19,8 @@ const bucketSizeBits = 40
 
 const genSizeBits = 64 - bucketSizeBits
 
+const maxGen = 1<<genSizeBits - 1
+
 const maxBucketSize uint64 = 1 << bucketSizeBits
 
 // Stats represents cache stats.
@@ -262,7 +264,7 @@ func (b *bucket) Clean() {
 	for k, v := range bm {
 		gen := v >> bucketSizeBits
 		idx := v & ((1 << bucketSizeBits) - 1)
-		if gen == bGen && idx < bIdx || gen+1 == bGen && idx >= bIdx {
+		if gen == bGen && idx < bIdx || gen+1 == bGen && idx >= bIdx || gen == maxGen && bGen == 1 && idx >= bIdx {
 			continue
 		}
 		delete(bm, k)
@@ -352,7 +354,7 @@ func (b *bucket) Get(dst, k []byte, h uint64, returnDst bool) ([]byte, bool) {
 	if v > 0 {
 		gen := v >> bucketSizeBits
 		idx := v & ((1 << bucketSizeBits) - 1)
-		if gen == bGen && idx < b.idx || gen+1 == bGen && idx >= b.idx {
+		if gen == bGen && idx < b.idx || gen+1 == bGen && idx >= b.idx || gen == maxGen && bGen == 1 && idx >= b.idx {
 			chunkIdx := idx / chunkSize
 			if chunkIdx >= uint64(len(b.chunks)) {
 				// Corrupted data during the load from file. Just skip it.

--- a/fastcache_gen_test.go
+++ b/fastcache_gen_test.go
@@ -1,0 +1,97 @@
+package fastcache
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+)
+
+func TestGenerationOverflow(t *testing.T) {
+	c := New(1) // each bucket has 64 *1024 bytes capacity
+
+	// Initial generation is 1
+	genVal(t, c, 1)
+
+	// These two keys has to the same bucket (100), so we can push the
+	// generations up much faster.  The keys and values are sized so that
+	// every time we push them into the cache they will completely fill the
+	// bucket
+	key1 := []byte(strconv.Itoa(26))
+	bigVal1 := make([]byte, (32*1024)-(len(key1)+4))
+	for i := range bigVal1 {
+		bigVal1[i] = 1
+	}
+	key2 := []byte(strconv.Itoa(8))
+	bigVal2 := make([]byte, (32*1024)-(len(key2)+5))
+	for i := range bigVal2 {
+		bigVal2[i] = 2
+	}
+
+	// Do some initial Set/Get demonstrate that this works
+	for i := 0; i < 10; i++ {
+		c.Set(key1, bigVal1)
+		c.Set(key2, bigVal2)
+		getVal(t, c, key1, bigVal1)
+		getVal(t, c, key2, bigVal2)
+		genVal(t, c, uint64(1+i))
+	}
+
+	// This is a hack to simulate calling Set 2^24-3 times
+	// Actually doing this takes ~24 seconds, making the test slow
+	c.buckets[100].gen = (1 << 24) - 2
+
+	// After the next Set operations
+	// c.buckets[100].gen == 16,777,215
+	// Set/Get still works
+
+	c.Set(key1, bigVal1)
+	c.Set(key2, bigVal2)
+
+	getVal(t, c, key1, bigVal1)
+	getVal(t, c, key2, bigVal2)
+
+	genVal(t, c, (1<<24)-1)
+
+	// After the next Set operations
+	// c.buckets[100].gen == 16,777,216
+
+	// This set creates an index where `idx | (b.gen << bucketSizeBits)` == 0
+	// The value is in the cache but is unreadable by Get
+	c.Set(key1, bigVal1)
+
+	// This Set creates an index where `(b.gen << bucketSizeBits)>>bucketSizeBits)==0`
+	// The value is in the cache but is unreadable by Get
+	c.Set(key2, bigVal2)
+
+	// Ensure generations are working as we expect
+	genVal(t, c, (1 << 24))
+
+	getVal(t, c, key1, bigVal1)
+	getVal(t, c, key2, bigVal2)
+
+	// Do it a few more times to show that this bucket is now unusable
+	for i := 0; i < 3; i++ {
+		c.Set(key1, bigVal1)
+		c.Set(key2, bigVal2)
+		getVal(t, c, key1, bigVal1)
+		getVal(t, c, key2, bigVal2)
+		genVal(t, c, uint64((1<<24)+1+i))
+	}
+}
+
+func getVal(t *testing.T, c *Cache, key, expected []byte) {
+	t.Helper()
+	get := c.Get(nil, key)
+	if !bytes.Equal(get, expected) {
+		t.Errorf("Expected value (%v) was not returned from the cache, instead got %v", expected[:10], get)
+	}
+}
+
+func genVal(t *testing.T, c *Cache, expected uint64) {
+	t.Helper()
+	actual := c.buckets[100].gen
+	// Ensure generations are working as we expect
+	if actual != expected {
+		t.Fatalf("Expected generation to be %d found %d instead", expected, actual)
+	}
+}


### PR DESCRIPTION
There is an issue in the map implementation where the generation is put into the top 24 bits of the index stored in the hash->index map

https://github.com/VictoriaMetrics/fastcache/blob/master/fastcache.go#L339

This generation is then used to test whether the data in the cache is still valid.

https://github.com/VictoriaMetrics/fastcache/blob/master/fastcache.go#L352

The problem arises when the 24 bit value of the generation overflows at 16,777,216. The generation stored in the bucket is uint64, it continues to grow larger while the generation value stored in the index drops back to 0.

After this number of generations has been reached the data stored in the cache becomes unreadable as it will always fail the generation tests.

It is unlikely in practice that systems will experience this bug, but the fix is reasonably simple and doesn't compromise performance.