### PR TITLE
Fix taking the first error from workers in save

### DIFF
--- a/file.go
+++ b/file.go
@@ -118,7 +118,7 @@ func (c *Cache) save(dir string, workersCount int) error {
 	var err error
 	for i := 0; i < workersCount; i++ {
 		result := <-results
-		if result != nil && err != nil {
+		if result != nil && err == nil {
 			err = result
 		}
 	}


### PR DESCRIPTION
First of all, thanks for a nice library!

This pull request fixes for taking the first error result from workers in `save` method of `Cache`.