### PR TITLE
Support Iterator for fastcache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/VictoriaMetrics/fastcache
 
+go 1.15
+
 require (
 	github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156
 	github.com/cespare/xxhash/v2 v2.1.1

--- a/iterator.go
+++ b/iterator.go
@@ -1,0 +1,125 @@
+package fastcache
+
+import (
+	"sync"
+)
+
+type iteratorError string
+
+func (e iteratorError) Error() string {
+	return string(e)
+}
+
+// ErrIterationFinished is reported when Value() is called after reached to the end of the iterator
+const ErrIterationFinished = iteratorError("iterator reached the last element, Value() should not be called")
+
+var emptyEntry = Entry{}
+
+// Entry represents a key-value pair in fastcache
+type Entry struct {
+	key       []byte
+	value     []byte
+}
+
+// Key returns entry's key
+func (e Entry) Key() []byte {
+	return e.key
+}
+
+// Value returns entry's value
+func (e Entry) Value() []byte {
+	return e.value
+}
+
+func newIterator(c *Cache) *Iterator {
+	elements, count := c.buckets[0].copyKeys()
+
+	return &Iterator{
+		cache:          c,
+		currBucketIdx:  0,
+		currKeyIdx:     -1,
+		currBucketKeys: elements,
+		currBucketSize: count,
+	}
+}
+
+// Iterator allows to iterate over entries in the cache
+type Iterator struct {
+	mu               sync.Mutex
+	cache            *Cache
+	currBucketSize   int
+	currBucketIdx    int
+	currBucketKeys   [][]byte
+	currKeyIdx       int
+	currentEntryInfo Entry
+
+	valid bool
+}
+
+// SetNext moves to the next element and returns true if the value exists.
+func (it *Iterator) SetNext() bool {
+	it.mu.Lock()
+
+	it.valid = false
+	it.currKeyIdx++
+
+	// In case there are remaining currBucketKeys in the current bucket.
+	if it.currBucketSize > it.currKeyIdx {
+		it.valid = true
+		found := it.setCurrentEntry()
+		it.mu.Unlock()
+
+		// if not found, check the next entry
+		if !found {
+			return it.SetNext()
+		}
+		return true
+	}
+
+	// If we reached the end of a bucket, check the next one for further iteration.
+	for i := it.currBucketIdx + 1; i < len(it.cache.buckets); i++ {
+		it.currBucketKeys, it.currBucketSize = it.cache.buckets[i].copyKeys()
+
+		// bucket is not an empty one, use it for iteration
+		if it.currBucketSize > 0 {
+			it.currKeyIdx = 0
+			it.currBucketIdx = i
+			it.valid = true
+			found := it.setCurrentEntry()
+			it.mu.Unlock()
+
+			// if not found, check the next entry
+			if !found {
+				return it.SetNext()
+			}
+			return true
+		}
+	}
+	it.mu.Unlock()
+	return false
+}
+
+func (it *Iterator) setCurrentEntry() bool {
+	key := it.currBucketKeys[it.currKeyIdx]
+	val, found := it.cache.HasGet(nil, key)
+
+	if found {
+		it.currentEntryInfo = Entry{
+			key:   key,
+			value: val,
+		}
+	} else {
+		it.currentEntryInfo = emptyEntry
+	}
+
+	return found
+}
+
+// Value returns the current entry of an iterator.
+func (it *Iterator) Value() (Entry, error) {
+	if !it.valid {
+		return emptyEntry, ErrIterationFinished
+	}
+
+	return it.currentEntryInfo, nil
+}


### PR DESCRIPTION
- Spawned from https://github.com/VictoriaMetrics/fastcache/issues/43 - Iterator support?
- I've checked the previous iterator-like implementation, https://github.com/VictoriaMetrics/fastcache/pull/3
- This implementation avoids iterating the whole cache from a single function call. Instead, it copies keys from a bucket, not whole keys from a cache. And then it uses the copied key to retrieve the value from the cache. 

```
func TestCacheIterator(t *testing.T) {
	c := New(1024)
	defer c.Reset()

	numEntries := 100
	keyValMap := make(map[string][]byte)
	for i := 0; i < numEntries; i++ {
		k := []byte(fmt.Sprintf("key %d", i))
		v := []byte(fmt.Sprintf("value %d", i))
		c.Set(k, v)
		keyValMap[string(k)] = v
		vv := c.Get(nil, k)
		if string(vv) != string(v) {
			t.Fatalf("unexpected value for key %q; got %q; want %q", k, vv, v)
		}
	}

	itr := c.Iterator()
	for itr.SetNext() {
		entry, err := itr.Value()
		if err != nil {
			t.Fatal("unexpected error from itr.Value()", "err", err)
		}

		val, exist := keyValMap[string(entry.key)]
		if !exist {
			t.Fatal("failed to retrieve an entry from cache which should exist")
		}
		if !bytes.Equal(val, entry.value) {
			t.Fatalf("value from iterator is not the same as the expected one for key %q; got %q; want %q",
				entry.key, entry.value, val)
		}
	}
}
```