### PR TITLE
Fix surprising / unexpected behavior with `GetBig` when testing for cache misses

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -72,7 +72,7 @@ func (c *Cache) SetBig(k, v []byte) {
 // with values stored via other methods.
 //
 // k contents may be modified after returning from GetBig.
-func (c *Cache) GetBig(dst, k []byte) []byte {
+func (c *Cache) GetBig(dst, k []byte) (r []byte) {
 	atomic.AddUint64(&c.bigStats.GetBigCalls, 1)
 	subkey := getSubkeyBuf()
 	dstWasNil := dst == nil

--- a/bigcache.go
+++ b/bigcache.go
@@ -75,7 +75,15 @@ func (c *Cache) SetBig(k, v []byte) {
 func (c *Cache) GetBig(dst, k []byte) []byte {
 	atomic.AddUint64(&c.bigStats.GetBigCalls, 1)
 	subkey := getSubkeyBuf()
-	defer putSubkeyBuf(subkey)
+	dstWasNil := dst == nil
+	defer func() {
+                putSubkeyBuf(subkey)
+                if len(r) == 0 && dstWasNil {
+                        // Guarantee that if the caller provided nil and this is a cache miss that
+                        // the caller can accurately test for a cache miss with `if r == nil`.
+                        r = nil
+                }
+        }()
 
 	// Read and parse metavalue
 	subkey.B = c.Get(subkey.B[:0], k)

--- a/bigcache.go
+++ b/bigcache.go
@@ -83,7 +83,7 @@ func (c *Cache) GetBig(dst, k []byte) (r []byte) {
 			// the caller can accurately test for a cache miss with `if r == nil`.
 			r = nil
 		}
-        }()
+	}()
 
 	// Read and parse metavalue
 	subkey.B = c.Get(subkey.B[:0], k)

--- a/bigcache.go
+++ b/bigcache.go
@@ -77,12 +77,12 @@ func (c *Cache) GetBig(dst, k []byte) (r []byte) {
 	subkey := getSubkeyBuf()
 	dstWasNil := dst == nil
 	defer func() {
-                putSubkeyBuf(subkey)
-                if len(r) == 0 && dstWasNil {
-                        // Guarantee that if the caller provided nil and this is a cache miss that
-                        // the caller can accurately test for a cache miss with `if r == nil`.
-                        r = nil
-                }
+		putSubkeyBuf(subkey)
+		if len(r) == 0 && dstWasNil {
+			// Guarantee that if the caller provided nil and this is a cache miss that
+			// the caller can accurately test for a cache miss with `if r == nil`.
+			r = nil
+		}
         }()
 
 	// Read and parse metavalue


### PR DESCRIPTION
We ran into this in our prod environment. I think what happened was some of the sub-keys backing `SetBig` expired and we were doing something like:

```golang
result := cache.GetBig(nil, key)
if result == nil {
    // Cache miss
} else {
    // Cache hit
}
```

however what was happening was the data was *not* cached, but result would not be equal to nil which was pretty confusing. We fixed the code on our end to test for `len(result) > 0` but figured I'd make a patch for upstream to hopefully save someone else in the future