### PR TITLE
Substitute syscall by x/sys, support more platforms (e.g. Solaris).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.3
 	github.com/stretchr/testify v1.3.0 // indirect
+	golang.org/x/sys v0.0.0-20210324051608-47abb6519492
 )

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,5 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492 h1:Paq34FxTluEPvVyayQqMPgHm+vTOrIifmcYxFBx9TLg=
+golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/malloc_mmap.go
+++ b/malloc_mmap.go
@@ -5,8 +5,9 @@ package fastcache
 import (
 	"fmt"
 	"sync"
-	"syscall"
 	"unsafe"
+
+	syscall "golang.org/x/sys/unix"
 )
 
 const chunksPerAlloc = 1024


### PR DESCRIPTION
Fixes `../../!victoria!metrics/fastcache@v1.5.7/malloc_mmap.go:24:16: undefined: syscall.Mmap` on at least SmartOS.