### PR TITLE
Fix/memory leak in freelist

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -211,6 +211,13 @@ func (c *Cache) UpdateStats(s *Stats) {
 	s.InvalidValueHashErrors += atomic.LoadUint64(&c.bigStats.InvalidValueHashErrors)
 }
 
+func (c *Cache) ReloadFromFile(path string) error {
+	c.Reset()
+	var err error
+	c, err = load(c, path, 0)
+	return err
+}
+
 type bucket struct {
 	mu sync.RWMutex
 

--- a/fastcache.go
+++ b/fastcache.go
@@ -218,6 +218,11 @@ func (c *Cache) ReloadFromFile(path string) error {
 	return err
 }
 
+func (c *Cache) Close() error {
+	c.Reset()
+	return clearChunks()
+}
+
 type bucket struct {
 	mu sync.RWMutex
 

--- a/malloc_heap.go
+++ b/malloc_heap.go
@@ -9,3 +9,8 @@ func getChunk() []byte {
 func putChunk(chunk []byte) {
 	// No-op.
 }
+
+func clearChunks() error {
+	// No-op.
+	return nil
+}


### PR DESCRIPTION
This is related to [this issue](https://github.com/VictoriaMetrics/fastcache/issues/55).
- Add a `ReloadFromFile` method that will reset the current cache, returning all chunks to the freelist so that the `load` will reuse that memory instead of allocating and leaking new one
- Add a `Close` method to make sure that at the end of the `Cache` object lifecycle, all memory allocated through the freelist is deallocated