### PR TITLE
Enable malloc_heap.go on JS targets

### DIFF
--- a/malloc_heap.go
+++ b/malloc_heap.go
@@ -1,5 +1,5 @@
-//go:build appengine || windows
-// +build appengine windows
+//go:build appengine || windows || js
+// +build appengine windows js
 
 package fastcache
 

--- a/malloc_mmap.go
+++ b/malloc_mmap.go
@@ -1,5 +1,5 @@
-//go:build !appengine && !windows
-// +build !appengine,!windows
+//go:build !appengine && !windows && !js
+// +build !appengine,!windows,!js
 
 package fastcache
 


### PR DESCRIPTION
JS doesn't have mmap, so it needs to use the heap malloc backend.