### PR TITLE
fix:remove the duplicate code

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -246,7 +246,6 @@ func (b *bucket) Init(maxBytes uint64) {
 	}
 	maxChunks := (maxBytes + chunkSize - 1) / chunkSize
 	b.chunks = make([][]byte, maxChunks)
-	b.m = make(map[uint64]uint64)
 	b.Reset()
 }
 
@@ -260,11 +259,11 @@ func (b *bucket) Reset() {
 	b.m = make(map[uint64]uint64)
 	b.idx = 0
 	b.gen = 1
-	atomic.StoreUint64(&b.getCalls, 0)
-	atomic.StoreUint64(&b.setCalls, 0)
-	atomic.StoreUint64(&b.misses, 0)
-	atomic.StoreUint64(&b.collisions, 0)
-	atomic.StoreUint64(&b.corruptions, 0)
+	b.getCalls = 0
+	b.setCalls = 0
+	b.misses = 0
+	b.collisions = 0
+	b.corruptions = 0
 	b.mu.Unlock()
 }
 


### PR DESCRIPTION
1.Remove the duplicate code 'b.m = make(map[uint64]uint64)'
2.Because of the protection of the lock, you can operate without using atoms