### PR TITLE
stats: report effective cache usage instead of current chunk capacity

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -307,7 +307,7 @@ func (b *bucket) UpdateStats(s *Stats) {
 	s.EntriesCount += uint64(len(b.m))
 	bytesSize := uint64(0)
 	for _, chunk := range b.chunks {
-		bytesSize += uint64(cap(chunk))
+		bytesSize += uint64(len(chunk))
 	}
 	s.BytesSize += bytesSize
 	s.MaxBytesSize += uint64(len(b.chunks)) * chunkSize


### PR DESCRIPTION
`UpdateStats` reports the total available capacity of created chunks instead of the total space payload uses.
Proposing to change how `BytesSize` is calculated to report the size used by cache entities.