### PR TITLE
file: load should propage file not found error

### DIFF
--- a/file.go
+++ b/file.go
@@ -141,7 +141,7 @@ func load(filePath string, maxBytes int) (*Cache, error) {
 	// Read bucket files from filePath dir.
 	d, err := os.Open(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open %q: %s", filePath, err)
+		return nil, fmt.Errorf("cannot open %q: %w", filePath, err)
 	}
 	defer func() {
 		_ = d.Close()
@@ -206,7 +206,7 @@ func loadMetadata(dir string) (uint64, error) {
 	metadataPath := dir + "/metadata.bin"
 	metadataFile, err := os.Open(metadataPath)
 	if err != nil {
-		return 0, fmt.Errorf("cannot open %q: %s", metadataPath, err)
+		return 0, fmt.Errorf("cannot open %q: %w", metadataPath, err)
 	}
 	defer func() {
 		_ = metadataFile.Close()

--- a/file_test.go
+++ b/file_test.go
@@ -1,6 +1,7 @@
 package fastcache
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,6 +43,19 @@ func TestSaveLoadSmall(t *testing.T) {
 	vv = c1.Get(nil, key)
 	if string(vv) != string(newValue) {
 		t.Fatalf("unexpected new value obtained from cache; got %q; want %q", vv, newValue)
+	}
+}
+
+func TestLoadFileNotExist(t *testing.T) {
+	c, err := LoadFromFile(`non-existing-file`)
+	if err == nil {
+		t.Fatalf("LoadFromFile must return error; got nil")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LoadFromFile must return os.ErrNotExist; got: %s", err)
+	}
+	if c != nil {
+		t.Fatalf("LoadFromFile must return nil cache")
 	}
 }
 


### PR DESCRIPTION
So it could be handled by the caller. For example, here https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8952