### PR TITLE
file: load from file should allow configure maxBytes

### DIFF
--- a/file.go
+++ b/file.go
@@ -79,8 +79,8 @@ func (c *Cache) SaveToFileConcurrent(filePath string, concurrency int) error {
 // LoadFromFile loads cache data from the given filePath.
 //
 // See SaveToFile* for saving cache data to file.
-func LoadFromFile(filePath string) (*Cache, error) {
-	return load(filePath, 0)
+func LoadFromFile(filePath string, maxBytes int) (*Cache, error) {
+	return load(filePath, maxBytes)
 }
 
 // LoadFromFileOrNew tries loading cache data from the given filePath.

--- a/file_test.go
+++ b/file_test.go
@@ -28,7 +28,7 @@ func TestSaveLoadSmall(t *testing.T) {
 		t.Fatalf("SaveToFile error: %s", err)
 	}
 
-	c1, err := LoadFromFile(filePath)
+	c1, err := LoadFromFile(filePath, 0)
 	if err != nil {
 		t.Fatalf("LoadFromFile error: %s", err)
 	}
@@ -47,7 +47,7 @@ func TestSaveLoadSmall(t *testing.T) {
 }
 
 func TestLoadFileNotExist(t *testing.T) {
-	c, err := LoadFromFile(`non-existing-file`)
+	c, err := LoadFromFile(`non-existing-file`, 0)
 	if err == nil {
 		t.Fatalf("LoadFromFile must return error; got nil")
 	}
@@ -105,7 +105,7 @@ func testSaveLoadFile(t *testing.T, concurrency int) {
 	c.Reset()
 
 	// Verify LoadFromFile
-	c, err = LoadFromFile(filePath)
+	c, err = LoadFromFile(filePath, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
@@ -240,7 +240,7 @@ func TestSaveLoadConcurrent(t *testing.T) {
 				if err := c.SaveToFileConcurrent(filePath, 3); err != nil {
 					panic(fmt.Errorf("cannot save cache to %q: %s", filePath, err))
 				}
-				cc, err := LoadFromFile(filePath)
+				cc, err := LoadFromFile(filePath, 0)
 				if err != nil {
 					panic(fmt.Errorf("cannot load cache from %q: %s", filePath, err))
 				}

--- a/file_timing_test.go
+++ b/file_timing_test.go
@@ -51,7 +51,7 @@ func benchmarkLoadFromFile(b *testing.B, concurrency int) {
 	b.ResetTimer()
 	b.SetBytes(benchCacheSize)
 	for i := 0; i < b.N; i++ {
-		c, err := LoadFromFile(filePath)
+		c, err := LoadFromFile(filePath, 0)
 		if err != nil {
 			b.Fatalf("cannot load cache from file: %s", err)
 		}


### PR DESCRIPTION
It is needed to implement same behavior as `LoadFromFileOrNew` does. It respects given maxBytes and pass it to `load` so this check
https://github.com/VictoriaMetrics/fastcache/blob/e439f07b570777a09fb9b662e47bd52d895c349b/file.go#L133-L139 works.

Related to https://github.com/VictoriaMetrics/VictoriaMetrics/pull/8952/files