### PR TITLE
introduce new stats item EvictedBytes

### DIFF
--- a/fastcache.go
+++ b/fastcache.go
@@ -56,6 +56,9 @@ type Stats struct {
 	// MaxBytesSize is the maximum allowed size of the cache in bytes (aka capacity).
 	MaxBytesSize uint64
 
+	// EvictedBytes is the amount of bytes evicted from cache
+	EvictedBytes uint64
+
 	// BigStats contains stats for GetBig/SetBig methods.
 	BigStats
 }
@@ -234,8 +237,9 @@ type bucket struct {
 	// idx points to chunks for writing the next (k, v) pair.
 	idx uint64
 
-	collisions  uint64
-	corruptions uint64
+	collisions   uint64
+	corruptions  uint64
+	evictedBytes uint64
 }
 
 func (b *bucket) Init(maxBytes uint64) {
@@ -266,6 +270,7 @@ func (b *bucket) Reset() {
 	atomic.StoreUint64(&b.misses, 0)
 	atomic.StoreUint64(&b.collisions, 0)
 	atomic.StoreUint64(&b.corruptions, 0)
+	atomic.StoreUint64(&b.evictedBytes, 0)
 	b.mu.Unlock()
 }
 
@@ -303,6 +308,7 @@ func (b *bucket) UpdateStats(s *Stats) {
 	s.Misses += atomic.LoadUint64(&b.misses)
 	s.Collisions += atomic.LoadUint64(&b.collisions)
 	s.Corruptions += atomic.LoadUint64(&b.corruptions)
+	s.EvictedBytes += atomic.LoadUint64(&b.evictedBytes)
 
 	b.mu.RLock()
 	s.EntriesCount += uint64(len(b.m))
@@ -371,6 +377,7 @@ func (b *bucket) Set(k, v []byte, h uint64) {
 	b.idx = idxNew
 	if needClean {
 		b.cleanLocked()
+		atomic.AddUint64(&b.evictedBytes, uint64(len(chunks)*chunkSize))
 	}
 	b.mu.Unlock()
 }


### PR DESCRIPTION
 It's incremented on bucket clean up and reports bytes
evicted from memory. It should help to understand an amount of extra memory needed for fastcache to serve requests rate on constantly evicted keys.

Related PR https://github.com/VictoriaMetrics/VictoriaMetrics/pull/9293