### PR TITLE
.github: add explicit persist-credentials for checkout action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
         id: go
       - name: Code checkout
         uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819  # v1.0.0
+        with:
+          persist-credentials: false
       - name: Test
         run: |
           go test -v ./... -coverprofile=coverage.txt -covermode=atomic

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
           go-version: 1.24
         id: go
       - name: Code checkout
-        uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819  # v1.0.0
+        uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598  # v2.0.0
         with:
           persist-credentials: false
       - name: Test


### PR DESCRIPTION
Add explicit `persist-credentials` as it's `true` by default.
Note: Bumped `action/checkout` to `v2` as `persist-credentials` does not exist for `v1`.
More Info: https://github.com/actions/checkout/issues/485

cc: @arkid15r